### PR TITLE
Clarify API key auth comment and fix npm install in preBuild

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -6,7 +6,7 @@ backend:
         - nvm install 20
         - nvm use 20
         - node -v
-        - npm ci --cache .npm --prefer-offline
+        - npm install --cache .npm --prefer-offline
     build:
       commands:
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -33,7 +33,7 @@ const schema = a.schema({
     .authorization((allow) => [
       // Le propriétaire peut créer, lire, modifier et supprimer ses uploads (nécessite User Pool)
       allow.owner(),
-      // Lecture publique via API Key limitée aux items publiés (pas de list : évite l'exposition de données sensibles)
+      // Lecture publique ponctuelle via API Key (sans list) ; cette règle ne filtre pas automatiquement sur status
       allow.publicApiKey().to(["read"]),
     ]),
 


### PR DESCRIPTION
This pull request introduces a couple of minor but important updates to the build process and API authorization logic. The main changes include modifying the npm installation command in the build pipeline and clarifying the public API key authorization comment to better reflect the behavior of the rule.

Build process:

* Changed the npm installation step in `amplify.yml` from `npm ci` to `npm install` to potentially address compatibility or caching issues during CI builds.

API authorization:

* Updated the comment for the public API key rule in `resource.ts` to clarify that public read access is allowed via API key on a per-item basis (no list), and that the rule does not automatically filter on status.