### PR TITLE
Document supported Claude agent models for fallback handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,10 @@ To send us a pull request, please:
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
+### Claude coding agent
+
+If the GitHub Actions job **`claude`** fails with `model_not_available_for_integrator`, rerun the task with **Auto** or another currently supported Claude model instead of `claude-opus-4.6`.
+
 
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.


### PR DESCRIPTION
This pull request adds a helpful troubleshooting note to the `CONTRIBUTING.md` file for contributors using the Claude coding agent. The note explains what to do if the GitHub Actions job for Claude fails due to a model availability issue.

Documentation update:

* Added a section to `CONTRIBUTING.md` with instructions for rerunning the Claude GitHub Actions job using a supported model if the `model_not_available_for_integrator` error occurs with `claude-opus-4.6`.* Initial plan

* docs: document supported claude agent models

---------