### PR TITLE
Document supported Claude agent models and fallback plan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 ### Claude coding agent
 
-If the GitHub Actions job **`claude`** fails with `model_not_available_for_integrator`, rerun the task with **Auto** or another currently supported Claude model instead of `claude-opus-4.6`.
+If the GitHub Actions job **`claude`** fails with `model_not_available_for_integrator`, rerun the task with **Auto** or another currently supported Claude model instead of `claude-3-opus`.
 
 
 ## Finding contributions to work on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 ### Claude coding agent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ GitHub provides additional documentation on [forking a repository](https://help.
 
 ### Claude coding agent
 
-If you have a GitHub Actions job named **`claude`** and it fails with `model_not_available_for_integrator`, rerun the task with **Auto** or another currently supported Claude model instead of `claude-3-opus`.
+If you have a GitHub Actions job named **`claude`** and it fails with `model_not_available_for_integrator`, rerun the task with **Auto** or another currently supported Claude model instead of `claude-opus-4.6`.
 
 
 ## Finding contributions to work on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ GitHub provides additional documentation on [forking a repository](https://help.
 
 ### Claude coding agent
 
-If the GitHub Actions job **`claude`** fails with `model_not_available_for_integrator`, rerun the task with **Auto** or another currently supported Claude model instead of `claude-3-opus`.
+If you have a GitHub Actions job named **`claude`** and it fails with `model_not_available_for_integrator`, rerun the task with **Auto** or another currently supported Claude model instead of `claude-3-opus`.
 
 
 ## Finding contributions to work on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,10 @@ To send us a pull request, please:
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
+### Claude coding agent
+
+If the GitHub Actions job **`claude`** fails with `model_not_available_for_integrator`, rerun the task with **Auto** or another currently supported Claude model instead of `claude-opus-4.6`.
+
 
 ## Finding contributions to work on
 Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.


### PR DESCRIPTION
This pull request updates the `CONTRIBUTING.md` documentation to help contributors troubleshoot a specific failure scenario when using the Claude coding agent in GitHub Actions.

Documentation update:

* Added a section explaining what to do if you have a GitHub Actions job named `claude` and it fails with a `model_not_available_for_integrator` error, instructing users to rerun the task with "Auto" or another supported Claude model instead of `claude-3-opus`.

* Initial plan

* docs: document supported claude agent models

---------